### PR TITLE
Fix removed @*INC

### DIFF
--- a/test.pl
+++ b/test.pl
@@ -1,7 +1,5 @@
 use v6;
-
-BEGIN { @*INC.push: 'lib' }
-
+use lib 'lib';
 use MPD;
 
 my $a = MPD.new('localhost', 6600);


### PR DESCRIPTION
@*INC is no longer available. `use lib` is the new way.
